### PR TITLE
Specify handlers when unsubscribing from events on destroy.

### DIFF
--- a/src/jquery.touchsplitter.coffee
+++ b/src/jquery.touchsplitter.coffee
@@ -128,16 +128,16 @@
       @element.on 'touchcancel', @onTouchEnd
 
     destroy: (side) =>
-      @element.off('resize')
-      $(window).off('resize')
-      $(window).off('mouseup')
-      $(window).off 'mousemove'
-      @element.find('>.splitter-bar').off 'mousedown'
-      @element.find('>.splitter-bar').off 'touchstart'
-      @element.off 'touchmove'
-      @element.off 'touchend'
-      @element.off 'touchleave'
-      @element.off 'touchcancel'
+      @element.off('resize', @onResize)
+      $(window).off('resize', @onResizeWindow)
+      $(window).off('mouseup', @stopDragging)
+      $(window).off 'mousemove', @drag
+      @element.find('>.splitter-bar').off 'mousedown', @onMouseDown
+      @element.find('>.splitter-bar').off 'touchstart', @onTouchStart
+      @element.off 'touchmove', @onTouchMove
+      @element.off 'touchend', @onTouchEnd
+      @element.off 'touchleave', @onTouchEnd
+      @element.off 'touchcancel', @onTouchEnd
       @element.find('>.splitter-bar').remove()
       @element.removeClass('TouchSplitter h-ts v-ts docks-first docks-second docks-both')
       if side?

--- a/src/jquery.touchsplitter.js
+++ b/src/jquery.touchsplitter.js
@@ -180,16 +180,16 @@
 
       TouchSplitter.prototype.destroy = function(side) {
         var toRemove;
-        this.element.off('resize', this.onResize);
-        $(window).off('resize', this.onResizeWindow);
-        $(window).off('mouseup', this.stopDragging);
-        $(window).off('mousemove', this.drag);
-        this.element.find('>.splitter-bar').off('mousedown', this.onMouseDown);
-        this.element.find('>.splitter-bar').off('touchstart', this.onTouchStart);
-        this.element.off('touchmove', this.onTouchMove);
-        this.element.off('touchend', this.onTouchEnd);
-        this.element.off('touchleave', this.onTouchEnd);
-        this.element.off('touchcancel', this.onTouchEnd);
+        this.element.off('resize');
+        $(window).off('resize');
+        $(window).off('mouseup');
+        $(window).off('mousemove');
+        this.element.find('>.splitter-bar').off('mousedown');
+        this.element.find('>.splitter-bar').off('touchstart');
+        this.element.off('touchmove');
+        this.element.off('touchend');
+        this.element.off('touchleave');
+        this.element.off('touchcancel');
         this.element.find('>.splitter-bar').remove();
         this.element.removeClass('TouchSplitter h-ts v-ts docks-first docks-second docks-both');
         if (side != null) {

--- a/src/jquery.touchsplitter.js
+++ b/src/jquery.touchsplitter.js
@@ -180,16 +180,16 @@
 
       TouchSplitter.prototype.destroy = function(side) {
         var toRemove;
-        this.element.off('resize');
-        $(window).off('resize');
-        $(window).off('mouseup');
-        $(window).off('mousemove');
-        this.element.find('>.splitter-bar').off('mousedown');
-        this.element.find('>.splitter-bar').off('touchstart');
-        this.element.off('touchmove');
-        this.element.off('touchend');
-        this.element.off('touchleave');
-        this.element.off('touchcancel');
+        this.element.off('resize', this.onResize);
+        $(window).off('resize', this.onResizeWindow);
+        $(window).off('mouseup', this.stopDragging);
+        $(window).off('mousemove', this.drag);
+        this.element.find('>.splitter-bar').off('mousedown', this.onMouseDown);
+        this.element.find('>.splitter-bar').off('touchstart', this.onTouchStart);
+        this.element.off('touchmove', this.onTouchMove);
+        this.element.off('touchend', this.onTouchEnd);
+        this.element.off('touchleave', this.onTouchEnd);
+        this.element.off('touchcancel', this.onTouchEnd);
         this.element.find('>.splitter-bar').remove();
         this.element.removeClass('TouchSplitter h-ts v-ts docks-first docks-second docks-both');
         if (side != null) {


### PR DESCRIPTION
At the moment when destroying one `splitter` others stop working because `destroy` removes all handlers from window's events. This should fix it.